### PR TITLE
Avoid extraneous output, which can break JSON decoding

### DIFF
--- a/api.php
+++ b/api.php
@@ -1,4 +1,6 @@
 <?php
+    // use output buffering to capture any errors or extraneous output
+    ob_start();
 
     // get layout from ajax
     $layoutName = $_POST['layout'];
@@ -42,8 +44,10 @@
             $json->$fields[$i] = $record->getField($fields[$i], 0);
         }
     }
+    
+    // end buffering, discarding buffer
+    ob_end_clean();
 
     // return json {}
     echo json_encode($json);
-
-?>
+    exit;


### PR DESCRIPTION
Use output buffering to avoid extraneous output (errors, notices, etc).
`exit;` stops any future processing/output.
Remove closing `?>` to avoid trailing whitespace (not required by PHP).